### PR TITLE
Add gutterSize helper with parameters.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.1.0 - 2015-03-20
+
+✨ Adds `gutter()` value helper that returns calculated gutter size.
+
 # 1.0.0 - 2015-02-05
 
 ✨ First release, minimal features.

--- a/index.js
+++ b/index.js
@@ -77,11 +77,11 @@ var flexGridProcessor = function(style, opts) {
       decl.removeSelf();
     }
 
-    // Helper that returns gutter size as value
+    // Helper that returns gutter width as a percentage value
 
     // This helper receives 2 parameters:
     // `container_columns` => Amount of columns of the container element
-    // `gutter_size` => To override the main gutter size (Only if you know what you're doing)
+    // `gutter_width` => To override the main gutter width (Only if you know what you're doing)
 
     // Examples:
     // outerDiv {
@@ -89,9 +89,9 @@ var flexGridProcessor = function(style, opts) {
     // }
     // innerDiv {
     //   width: span(4);
-    //   margin-left: gutterSize(6);
+    //   margin-left: gutter(6);
     // }
-    if (decl.value !== null && decl.value.indexOf('gutterSize(') !== -1) {
+    if (decl.value !== null && decl.value.indexOf('gutter(') !== -1) {
       cols = decl.value.match(asValueRE);
       container_columns = cols && cols[1];
       gutter_width = cols && cols[2];

--- a/index.js
+++ b/index.js
@@ -77,6 +77,27 @@ var flexGridProcessor = function(style, opts) {
       decl.removeSelf();
     }
 
+    // Helper that returns gutter size as value
+
+    // This helper receives 2 parameters:
+    // `container_columns` => Amount of columns of the container element
+    // `gutter_size` => To override the main gutter size (Only if you know what you're doing)
+
+    // Examples:
+    // outerDiv {
+    //   span: 6 of 12;
+    // }
+    // innerDiv {
+    //   width: span(4);
+    //   margin-left: gutterSize(6);
+    // }
+    if (decl.value !== null && decl.value.indexOf('gutterSize(') !== -1) {
+      cols = decl.value.match(asValueRE);
+      container_columns = cols && cols[1];
+      gutter_width = cols && cols[2];
+      decl.value = flexGutter(container_columns, gutter_width) + '%';
+    }
+
   });
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "postcss-flexgrid",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "PostCSS helpers for defining a flexible grid in PostCSS",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Adds `gutter(container_columns, gutter_width)` value helper for some specific use cases.

Example:

``` css
outerDiv {
  width: span(8 of 12);
}

innerDiv {
  width: span(4 of 8);
  margin-right: gutter(8);
}
```

Please note that passing `gutter_width` parameter will override the global gutter width only in this declaration. This is only included for very specific scenarios.
